### PR TITLE
Beta

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       # SOURCE_EMAIL: .com
       # SPF_ALLOW_LIST: 'pass, permerror, fail, temperror, softfail, none, neutral'
       # DKIM_REJECT: True
+      # DKIM_MIN_KEY: 1024
       # EMAIL_SIZE: 5048576
       # LOGGER: INFO
       # WEBHOOK_URL: https://webhookbin.net/v1/bin/4142fd66-fca8-4c36-bc04-cfa17c092a0d

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ source_email = genlist(environ.get('SOURCE_EMAIL',None))
 spf_allow_list = genlist(environ.get('SPF_ALLOW_LIST',None))
 
 dkim_reject = bool(environ.get('DKIM_REJECT',False))
-dkim_minkey = environ.get('DKIM_MIN_KEY',1024)
+dkim_minkey = int(environ.get('DKIM_MIN_KEY',1024))
 
 ident = environ.get('IDENT','')
 email_size = int(environ.get('EMAIL_SIZE',5048576))
@@ -103,7 +103,7 @@ class InboundChecker:
 
     async def handle_DATA(self, server: SMTPServer, session: SMTPSession, envelope: SMTPEnvelope):
         
-        global webhook_headers # Dirty fix but is needed in case there is no addon
+        global webhook_headers # Dirty fix but is needed in case there is no addon.. temporary
         global webhook
 
         email:MIMEPart = Parser(policy=default).parsestr(envelope.content.decode('utf8', errors='replace'))

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ source_email = genlist(environ.get('SOURCE_EMAIL',None))
 spf_allow_list = genlist(environ.get('SPF_ALLOW_LIST',None))
 
 dkim_reject = bool(environ.get('DKIM_REJECT',False))
+dkim_minkey = environ.get('DKIM_MIN_KEY',1024)
 
 ident = environ.get('IDENT','')
 email_size = int(environ.get('EMAIL_SIZE',5048576))
@@ -107,7 +108,7 @@ class InboundChecker:
 
         email:MIMEPart = Parser(policy=default).parsestr(envelope.content.decode('utf8', errors='replace'))
 
-        dkimverify = verify(envelope.content)
+        dkimverify = verify(envelope.content,minkey=dkim_minkey)
         
         if dkim_reject:
             Logger.debug(f'DKIM is: {dkimverify} : {envelope.mail_from} : {envelope.rcpt_tos[0]}')

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ The following environment variables can  be set to configure the SMTP server:
 - `SOURCE_EMAIL`: An optional email address to filter incoming emails by. If set, the SMTP server will only accept emails that are sent from this email address. It uses .endswith and accepts a list seperated by `","` `'.com, @example.com, example@example.com'` or a single email `'example@example.com'`
 - `SPF_ALLOW_LIST`: An optional string containing a list of allowed SPF responses `'pass, permerror, fail, temperror, softfail, none, neutral'`.
 - `DKIM_REJECT`: An optional boolean value indicating whether to reject emails that fail DKIM verification. If set to anything, any email that fails DKIM verification will be rejected. If not set, emails will not be rejected based on DKIM verification.
+- `DKIM_MIN_KEY`: Minimum allowed key size for DKIM verification only need to change if working with legacy systems. default is `1024`
 - `IDENT`: An optional string that will be used as the identity string for the SMTP server. Defaults to an empty string.
 - `EMAIL_SIZE`: An optional integer value indicating the maximum size of an incoming email, in bytes. Defaults to `5048576`.
 - `LOGGER`: An optinal string accepting `DEBUG,INFO,OFF` will print out info about incoming emails, default is `INFO`.


### PR DESCRIPTION
Added support for older dkim keys that run lower bit keys, seems to be more common than you would think.

- `DKIM_MIN_KEY`: Minimum allowed key size for DKIM verification only need to change if working with legacy systems. default is `1024`